### PR TITLE
Bump ua-parser-js and browser-sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1943,9 +1943,9 @@
             "dev": true
         },
         "ansi-regex": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true
         },
         "ansi-styles": {
@@ -2304,21 +2304,22 @@
             "dev": true
         },
         "browser-sync": {
-            "version": "2.27.11",
-            "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.27.11.tgz",
-            "integrity": "sha512-U5f9u97OYJH66T0MGWWzG9rOQTW6ZmDMj97vsmtqwNS03JAwdLVES8eel2lD3rvAqQCNAFqaJ74NMacBI57vJg==",
+            "version": "2.28.3",
+            "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.28.3.tgz",
+            "integrity": "sha512-gublDeevvAuypnc01SQNGL8fkm4RdIkEagnAJ8Tl9mvr2td3Pl4nVIg5S6fcgoMDEWb8IT7nUHG9YwTATn/k2g==",
             "dev": true,
             "requires": {
-                "browser-sync-client": "^2.27.11",
-                "browser-sync-ui": "^2.27.11",
+                "browser-sync-client": "^2.28.3",
+                "browser-sync-ui": "^2.28.3",
                 "bs-recipes": "1.3.4",
                 "bs-snippet-injector": "^2.0.1",
+                "chalk": "4.1.2",
                 "chokidar": "^3.5.1",
                 "connect": "3.6.6",
                 "connect-history-api-fallback": "^1",
                 "dev-ip": "^1.0.1",
                 "easy-extender": "^2.3.4",
-                "eazy-logger": "3.1.0",
+                "eazy-logger": "^4.0.1",
                 "etag": "^1.8.1",
                 "fresh": "^0.5.2",
                 "fs-extra": "3.0.1",
@@ -2337,7 +2338,7 @@
                 "serve-static": "1.13.2",
                 "server-destroy": "1.0.1",
                 "socket.io": "^4.4.1",
-                "ua-parser-js": "1.0.2",
+                "ua-parser-js": "^1.0.33",
                 "yargs": "^17.3.1"
             },
             "dependencies": {
@@ -2442,9 +2443,9 @@
             }
         },
         "browser-sync-client": {
-            "version": "2.27.11",
-            "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.27.11.tgz",
-            "integrity": "sha512-okMNfD2NasL/XD1/BclP3onXjhahisk3e/kTQ5HPDT/lLqdBqNDd6QFcjI5I1ak7na2hxKQSLjryql+7fp5gKQ==",
+            "version": "2.28.3",
+            "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.28.3.tgz",
+            "integrity": "sha512-SMsnGkyXlySVLBWRrXdnTdtQCy0Sl5UoiF8BVtigj9S49DaPWQiesbsyq+uJBUKgpyNve+cvfpBU3KSfIp6oLQ==",
             "dev": true,
             "requires": {
                 "etag": "1.8.1",
@@ -2455,12 +2456,13 @@
             }
         },
         "browser-sync-ui": {
-            "version": "2.27.11",
-            "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.27.11.tgz",
-            "integrity": "sha512-1T/Y8Pp1R68aUL7zVSFq0nxtr258xWd/nTasCAHX2M6EsGaswVOFtXsw3bKqsr35z+J+LfVfOdz1HFLYKxdgrA==",
+            "version": "2.28.3",
+            "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.28.3.tgz",
+            "integrity": "sha512-Mj5M+O3jroGp5hlO6pDfUo19wzUTIuvGyzaRrJAYUgsSkpFacrX+MLCjN9VbZm9fYXbtHyIsnIUUIlYag87wgQ==",
             "dev": true,
             "requires": {
                 "async-each-series": "0.1.1",
+                "chalk": "4.1.2",
                 "connect-history-api-fallback": "^1",
                 "immutable": "^3",
                 "server-destroy": "1.0.1",
@@ -3611,12 +3613,12 @@
             }
         },
         "eazy-logger": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-3.1.0.tgz",
-            "integrity": "sha512-/snsn2JqBtUSSstEl4R0RKjkisGHAhvYj89i7r3ytNUKW12y178KDZwXLXIgwDqLW6E/VRMT9qfld7wvFae8bQ==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-4.0.1.tgz",
+            "integrity": "sha512-2GSFtnnC6U4IEKhEI7+PvdxrmjJ04mdsj3wHZTFiw0tUtG4HCWzTr13ZYTk8XOGnA1xQMaDljoBOYlk3D/MMSw==",
             "dev": true,
             "requires": {
-                "tfunk": "^4.0.0"
+                "chalk": "4.1.2"
             }
         },
         "ee-first": {
@@ -3673,9 +3675,9 @@
             "dev": true
         },
         "engine.io": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.2.1.tgz",
-            "integrity": "sha512-ECceEFcAaNRybd3lsGQKas3ZlMVjN3cyWwMP25D2i0zWfyiytVbTpRPa34qrr+FHddtpBVOmq4H/DCv1O0lZRA==",
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.4.1.tgz",
+            "integrity": "sha512-JFYQurD/nbsA5BSPmbaOSLa3tSVj8L6o4srSwXXY3NqE+gGUNmmPTbhn8tjzcCtSqhFgIeqef81ngny8JM25hw==",
             "dev": true,
             "requires": {
                 "@types/cookie": "^0.4.1",
@@ -3687,7 +3689,7 @@
                 "cors": "~2.8.5",
                 "debug": "~4.3.1",
                 "engine.io-parser": "~5.0.3",
-                "ws": "~8.2.3"
+                "ws": "~8.11.0"
             },
             "dependencies": {
                 "cookie": {
@@ -3697,38 +3699,38 @@
                     "dev": true
                 },
                 "ws": {
-                    "version": "8.2.3",
-                    "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-                    "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+                    "version": "8.11.0",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+                    "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
                     "dev": true
                 }
             }
         },
         "engine.io-client": {
-            "version": "6.2.3",
-            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.2.3.tgz",
-            "integrity": "sha512-aXPtgF1JS3RuuKcpSrBtimSjYvrbhKW9froICH4s0F3XQWLxsKNxqzG39nnvQZQnva4CMvUK63T7shevxRyYHw==",
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.4.0.tgz",
+            "integrity": "sha512-GyKPDyoEha+XZ7iEqam49vz6auPnNJ9ZBfy89f+rMMas8AuiMWOZ9PVzu8xb9ZC6rafUqiGHSCfu22ih66E+1g==",
             "dev": true,
             "requires": {
                 "@socket.io/component-emitter": "~3.1.0",
                 "debug": "~4.3.1",
                 "engine.io-parser": "~5.0.3",
-                "ws": "~8.2.3",
+                "ws": "~8.11.0",
                 "xmlhttprequest-ssl": "~2.0.0"
             },
             "dependencies": {
                 "ws": {
-                    "version": "8.2.3",
-                    "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-                    "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+                    "version": "8.11.0",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+                    "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
                     "dev": true
                 }
             }
         },
         "engine.io-parser": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.5.tgz",
-            "integrity": "sha512-mjEyaa4zhuuRhaSLOdjEb57X0XPP9JEsnXI4E+ivhwT0GgzUogARx4MqoY1jQyB+4Bkz3BUOmzL7t9RMKmlG3g==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.6.tgz",
+            "integrity": "sha512-tjuoZDMAdEhVnSFleYPCtdL2GXwVTGtNjoeJd9IhIG3C1xs9uwxqRNEu5WpnDZCaozwVlK/nuQhpodhXSIMaxw==",
             "dev": true
         },
         "enhanced-resolve": {
@@ -4386,15 +4388,6 @@
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
             "requires": {
                 "function-bind": "^1.1.1"
-            }
-        },
-        "has-ansi": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-            "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
-            "dev": true,
-            "requires": {
-                "ansi-regex": "^2.0.0"
             }
         },
         "has-flag": {
@@ -5252,12 +5245,6 @@
                 "yargs": "17.1.1"
             },
             "dependencies": {
-                "ansi-regex": {
-                    "version": "5.0.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-                    "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-                    "dev": true
-                },
                 "axios": {
                     "version": "0.21.4",
                     "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
@@ -5292,15 +5279,6 @@
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
                     "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
                     "dev": true
-                },
-                "strip-ansi": {
-                    "version": "6.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-                    "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^5.0.1"
-                    }
                 },
                 "yargs": {
                     "version": "17.1.1",
@@ -6508,9 +6486,9 @@
             "dev": true
         },
         "raw-body": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-            "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+            "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
             "dev": true,
             "requires": {
                 "bytes": "3.1.2",
@@ -7156,41 +7134,52 @@
             "dev": true
         },
         "socket.io": {
-            "version": "4.5.4",
-            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.4.tgz",
-            "integrity": "sha512-m3GC94iK9MfIEeIBfbhJs5BqFibMtkRk8ZpKwG2QwxV0m/eEhPIV4ara6XCF1LWNAus7z58RodiZlAH71U3EhQ==",
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.6.1.tgz",
+            "integrity": "sha512-KMcaAi4l/8+xEjkRICl6ak8ySoxsYG+gG6/XfRCPJPQ/haCRIJBTL4wIl8YCsmtaBovcAXGLOShyVWQ/FG8GZA==",
             "dev": true,
             "requires": {
                 "accepts": "~1.3.4",
                 "base64id": "~2.0.0",
                 "debug": "~4.3.2",
-                "engine.io": "~6.2.1",
-                "socket.io-adapter": "~2.4.0",
+                "engine.io": "~6.4.1",
+                "socket.io-adapter": "~2.5.2",
                 "socket.io-parser": "~4.2.1"
             }
         },
         "socket.io-adapter": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.4.0.tgz",
-            "integrity": "sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg==",
-            "dev": true
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz",
+            "integrity": "sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==",
+            "dev": true,
+            "requires": {
+                "ws": "~8.11.0"
+            },
+            "dependencies": {
+                "ws": {
+                    "version": "8.11.0",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+                    "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+                    "dev": true
+                }
+            }
         },
         "socket.io-client": {
-            "version": "4.5.4",
-            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.5.4.tgz",
-            "integrity": "sha512-ZpKteoA06RzkD32IbqILZ+Cnst4xewU7ZYK12aS1mzHftFFjpoMz69IuhP/nL25pJfao/amoPI527KnuhFm01g==",
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.6.1.tgz",
+            "integrity": "sha512-5UswCV6hpaRsNg5kkEHVcbBIXEYoVbMQaHJBXJCyEQ+CiFPV1NIOY0XOFWG4XR4GZcB8Kn6AsRs/9cy9TbqVMQ==",
             "dev": true,
             "requires": {
                 "@socket.io/component-emitter": "~3.1.0",
                 "debug": "~4.3.2",
-                "engine.io-client": "~6.2.3",
+                "engine.io-client": "~6.4.0",
                 "socket.io-parser": "~4.2.1"
             }
         },
         "socket.io-parser": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.1.tgz",
-            "integrity": "sha512-V4GrkLy+HeF1F/en3SpUaM+7XxYXpuMUWLGde1kSSh5nQMN4hLrbPIkD+otwh6q9R6NOQBN4AMaOZ2zVjui82g==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.2.tgz",
+            "integrity": "sha512-DJtziuKypFkMMHCm2uIshOYC7QaylbtzQwiMYDuCKy3OPkjLzu4B2vAhTlqipRHHzrI0NJeBAizTK7X+6m1jVw==",
             "dev": true,
             "requires": {
                 "@socket.io/component-emitter": "~3.1.0",
@@ -7398,12 +7387,12 @@
             }
         },
         "strip-ansi": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
             "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "^5.0.1"
             }
         },
         "strip-final-newline": {
@@ -7678,43 +7667,6 @@
                 }
             }
         },
-        "tfunk": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/tfunk/-/tfunk-4.0.0.tgz",
-            "integrity": "sha512-eJQ0dGfDIzWNiFNYFVjJ+Ezl/GmwHaFTBTjrtqNPW0S7cuVDBrZrmzUz6VkMeCR4DZFqhd4YtLwsw3i2wYHswQ==",
-            "dev": true,
-            "requires": {
-                "chalk": "^1.1.3",
-                "dlv": "^1.1.3"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                    "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
-                    "dev": true
-                }
-            }
-        },
         "thunky": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
@@ -7780,15 +7732,15 @@
             }
         },
         "typescript": {
-            "version": "4.9.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-            "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+            "version": "4.9.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "dev": true
         },
         "ua-parser-js": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.2.tgz",
-            "integrity": "sha512-00y/AXhx0/SsnI51fTc0rLRmafiGOM4/O+ny10Ps7f+j/b8p/ZY11ytMgznXkOVo4GQ+KwQG5UQLkLGirsACRg==",
+            "version": "1.0.34",
+            "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.34.tgz",
+            "integrity": "sha512-K9mwJm/DaB6mRLZfw6q8IMXipcrmuT6yfhYmwhAkuh+81sChuYstYA+znlgaflUPaYUa3odxKPKGw6Vw/lANew==",
             "dev": true
         },
         "unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "devDependencies": {
         "axios": "^0.21",
         "bootstrap": "^4.0.0",
-        "browser-sync": "^2.27.11",
+        "browser-sync": "^2.28.3",
         "browser-sync-webpack-plugin": "^2.0.1",
         "cross-env": "^7.0",
         "jquery": "^3.5",


### PR DESCRIPTION
Bumps [ua-parser-js](https://github.com/faisalman/ua-parser-js) to 1.0.34 and updates ancestor dependency [browser-sync](https://github.com/BrowserSync/browser-sync). These dependencies need to be updated together.


Updates `ua-parser-js` from 1.0.2 to 1.0.34
- [Release notes](https://github.com/faisalman/ua-parser-js/releases)
- [Changelog](https://github.com/faisalman/ua-parser-js/blob/1.0.34/changelog.md)
- [Commits](https://github.com/faisalman/ua-parser-js/compare/1.0.2...1.0.34)

Updates `browser-sync` from 2.27.11 to 2.28.3
- [Release notes](https://github.com/BrowserSync/browser-sync/releases)
- [Changelog](https://github.com/BrowserSync/browser-sync/blob/master/CHANGELOG.md)
- [Commits](https://github.com/BrowserSync/browser-sync/compare/v2.27.11...v2.28.3)

---
updated-dependencies:
- dependency-name: ua-parser-js dependency-type: indirect
- dependency-name: browser-sync dependency-type: direct:development ...